### PR TITLE
Enable manual trigger of NIGHTLY workflow

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -1,6 +1,7 @@
 name: Nightly Build
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 0 * * *'
 


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the NIGHLY build so it can be triggered at any time if needed; such as if the NIGHTLY fails.

This was done in support of addressing #26 